### PR TITLE
fixed the post_fit action

### DIFF
--- a/actions/get_fabric_ips.py
+++ b/actions/get_fabric_ips.py
@@ -34,7 +34,7 @@ class fabricIpLookup(HpecfmBaseAction):
                 if desc == '':
                     desc = 'HPE Composable Fabric'
                 out ={
-                        'u_desc':fabip['description'],
+                        'u_desc':desc,
                         'u_fabu_uid':fabip['fabric_uuid'],
                         'u_name':fabip['name'],
                         'u_mode':fabip['mode'],

--- a/actions/get_fabrics.py
+++ b/actions/get_fabrics.py
@@ -35,7 +35,7 @@ class fabricLookup(HpecfmBaseAction):
                 if desc == '':
                     desc = 'HPE Composable Fabric'
                 out ={
-                        'u_desc':fab['description'],
+                        'u_desc':desc,
                         'u_uuid':fab['uuid'],
                         'u_name':fab['name'],
                         'u_stable':fab['is_stable'],

--- a/actions/post_fit.py
+++ b/actions/post_fit.py
@@ -21,12 +21,12 @@
 # A python script for sending a 'fit' to the cfm controller
 
 from pyhpecfm import fabric
-from lib.action import HpecfmBaseAction
+from lib.actions import HpecfmBaseAction
 
 class FabricFit(HpecfmBaseAction):
     def run(self, fab_uuid=None, name=None, description=None):
         # Send fit request to the plexxi controller
-        status = fabric.perform_fit(self.client, fab_uuid, name, description)
-        if status == 200:
-            return(True, status)
-        return (False, status)
+        result = fabric.perform_fit(self.client, fab_uuid, name, description)
+        if result.status_code == 200:
+            return(True, result.status_code)
+        return (False, result.status_code)

--- a/actions/workflows/getfabric_for_fit.yaml
+++ b/actions/workflows/getfabric_for_fit.yaml
@@ -3,7 +3,7 @@ version: 1.0
 description: A workflow to get the fabric uuid, name and perform fit on CFM controller.
 
 tasks:
-  getswitches:
+  getfabrics:
     action: hpecfm.get_fabrics
     next:
       - when: <% succeeded() %>


### PR DESCRIPTION
The post_fit action was looking for 200 in result and not result.status_code as required. This would cause the action to fail in stackstorm but actually complete the fit on the CFM controller.